### PR TITLE
adds CLI exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,82 +7,35 @@ flows which have pass, fail, or warn. This CLI utility combines `npm outdated` a
 a compliance period for dependency checks. This way if a dependency update is within your compliance period you can
 trigger a warn or if it's beyond your compliance period it can trigger a fail.
 
+## Installation
+
+Most usecases you will want to install this as a project dependency using `yarn add --dev @ominestre/rotten-deps` or `npm i --save-dev @ominestre/rotten-deps`.
+Then you can create a task in `package.json` to run. You can use `rotten-deps --help` or checkout the CLI section before for options.
+
+## Config File
+
+TBD
+
+## CLI
+
+### Options
+
+#### `--config-path <string>`
+
+Specifies a path to your configuration file
+
+#### `--json`
+
+The output will be json instead of a table. Useful if you're consuming this output programmatically.
+
+### Exit Code Meanings
+
+* `0` indicates that no depedencies are stale or outdated
+* `1` indicates that you have outdated dependencies
+* `2` indicates that you have stale dependencies but no outdated
+
+You can use this in various CI pips to flag the task as good, warn, or fail.
+
 ## API
 
-### configuration.createFileReader( absoluteFilePath: string ) => function
-
-Creates a wrapper of `fs.readFileSync` using the provided absolute path for execution down
-the road.
-
-```javascript
-import { configuration } from '@ominestre/rotten-deps';
-
-const foo = async () => {
-  const reader = configuration.createFileReader('/some/absolute/path');
-  const data = await reader();
-  // do stuff with data
-}
-```
-
----
-
-### configuration.creatConfig( userConfig = {} ) => object
-
-Builds a user configuration object **without any validation** by taking a default config and
-overlaying the provided user config.
-
----
-
-### configuration.hasValidRules( rules: Rule[] ) => boolean
-
-```javascript
-type Rule = {
-  dependencyName: string,
-  ingore: boolean,
-  daysUntilExpiration: number
-}
-```
-
-Checks to make sure the configured rules match the expected type above
-
----
-
-### npm.createOutdatedRequest() => function() => Promise<object>
-
-Creates a deferred call to `npm outdated --json` that can be invoked later. The inner function
-returns a promise which handles a successful list of outdated dependencies resulting in a
-failed command. It will either resolve an object or bubble up any valid exceptions in running
-the command.
-
-```javascript
-import { npm } from '@ominestre/rotten-deps';
-
-const foo = async () => {
-  const getOutdatedRequest = npm.createOutdatedRequest();
-
-  try {
-    const data = getOutdatedRequest();
-    // do stuff with response
-  } catch (err) {
-    // put out the fire
-  }
-};
-```
-
----
-
-### npm.createDetailsRequest( dependencyName: string ) => function() => Promise<object>
-
-Creates a deferred call to `npm view --json X` where `X` is a dependency name.
-
-```javascript
-import { npm } from '@ominestre/rotten-deps';
-
-const foo = async () => {
-  const getDetails = createDetailsRequest('@foo/bar');
-  const dependencyInfo = await getDetails();
-  // do stuff with info
-};
-```
-
----
+TBD

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "npm run clean && tsc",
     "start": "npm run build && node ./bin/rotten-deps --config-path ./sample-config.json",
     "clean": "rimraf ./lib ./bin",
-    "pretest": "(cd test/dummies/sample-app && npm install --no-audit)",
-    "test": "mocha -r ts-node/register"
+    "pretest": "(cd test/dummies/sample-app && npm install --no-audit) && npm run build",
+    "test": "mocha -r ts-node/register test/*"
   },
   "author": {
     "name": "Mike Miller",
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@babel/core": "~7.10.5",
     "@babel/preset-env": "~7.10.3",
+    "@types/mocha": "^8.0.0",
     "@types/node": "~14.0.14",
     "@types/yargs": "~15.0.5",
     "@typescript-eslint/parser": "~3.7.1",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,12 +5,13 @@ import type { Config } from './config';
 import type { OutdatedPackage } from './npm-interactions';
 
 export interface ReportData {
-  name: string,
-  current: string,
-  latest: string,
-  daysOutdated: number,
-  isOutdated: boolean,
-  isIgnored: boolean,
+  readonly name: string,
+  readonly current: string,
+  readonly latest: string,
+  readonly daysOutdated: number,
+  readonly isOutdated: boolean,
+  readonly isIgnored: boolean,
+  readonly isStale: boolean,
 }
 
 export const generateReport = async (c: Config): Promise<ReportData[]|Error> => {
@@ -46,11 +47,15 @@ export const generateReport = async (c: Config): Promise<ReportData[]|Error> => 
 
       let isOutdated = false;
       let isIgnored = false;
+      let isStale = false;
 
       const rule = rules.filter(x => x.dependencyName === name).shift();
 
       if (!rule) isOutdated = true;
-      if (rule && rule.daysUntilExpiration <= daysOutdated) isOutdated = true
+
+      if (rule && rule.daysUntilExpiration <= daysOutdated) isOutdated = true;
+      if (rule && rule.daysUntilExpiration > daysOutdated) isStale = true;
+
       if (rule && rule.ignore) {
         isIgnored = true;
         isOutdated = false;
@@ -63,6 +68,7 @@ export const generateReport = async (c: Config): Promise<ReportData[]|Error> => 
         daysOutdated,
         isOutdated,
         isIgnored,
+        isStale,
       });
     });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -26,13 +26,30 @@ describe('API integrations', () => {
 
     if (maybeReport instanceof Error) throw maybeReport;
 
-    const leftPadLOL = maybeReport.filter(x => x.name === 'left-pad')[0];
+    const filter = name => maybeReport.filter(x => x.name === name).shift();
+    const leftPadLOL = filter('left-pad');
+    const mocha = filter('mocha');
+    const chai = filter('chai');
 
     assert.equal(leftPadLOL.name, 'left-pad');
     assert.equal(leftPadLOL.current, '1.2.0');
     assert.isTrue(leftPadLOL.daysOutdated < 9000, 'Days Outdated should be less than 9000');
     assert.isFalse(leftPadLOL.isOutdated, 'left-pad should not be flagged as outdated');
-  }).timeout(8000);
+    assert.isTrue(leftPadLOL.isStale, 'left-pad 1.2 should be flagged as stale since 1.3 is latest');
+
+    assert.equal(mocha.name, 'mocha');
+    assert.equal(mocha.current, '2.5.3');
+    assert.isTrue(mocha.isIgnored);
+    assert.isFalse(mocha.isOutdated);
+    assert.isFalse(mocha.isStale);
+
+    assert.equal(chai.name, 'chai');
+    assert.equal(chai.current, '1.8.1');
+    assert.isTrue(chai.daysOutdated > 1800);
+    assert.isTrue(chai.isOutdated);
+    assert.isFalse(chai.isIgnored);
+    assert.isFalse(chai.isStale);
+  }).timeout(20000);
 
   /*  Sitting on this one because you should just be using npm or yarn outdated.
       Not sure I want to support this scenario */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+import { assert } from 'chai';
+
+interface CommandResponse {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+type ConfigName = 'rules-only-config.json' | 'only-stale.json' | 'no-outdated.json';
+
+const rotten = (configFileName: ConfigName, enableJSON = false): CommandResponse => {
+  const configPath = join(__dirname, `dummies/${configFileName}`);
+  const dummyApp = join(__dirname, 'dummies/sample-app/');
+  const binaryPath = join(__dirname, '../bin/rotten-deps');
+
+  const args = [binaryPath, '--config-path', configPath];
+
+  if (enableJSON) args.push('--json');
+
+  const out = spawnSync(
+    'node',
+    args,
+    { cwd: dummyApp, timeout: 15000, encoding: 'utf8' },
+  );
+
+  const { status, stdout, stderr } = out;
+
+  return { status, stdout, stderr }
+};
+
+describe('CLI', () => {
+  it('should generate a report and exit 1 for outdated', async () => {
+    const { status, stdout, stderr } = await rotten('rules-only-config.json');
+    assert.equal(status, 1, 'rules only config should have outdated dependencies');
+    assert.isTrue(stdout.includes('left-pad'));
+    assert.isTrue(stdout.includes('mocha'));
+    assert.isTrue(stdout.includes('chai'));
+    assert.equal(stderr.length, 0, 'there should not be any error output for rules only config');
+  }).timeout(20000);
+
+  it('should generate a report and exit 0 for no outdated', async () => {
+    const { status } = await rotten('no-outdated.json');
+    assert.equal(status, 0);
+  }).timeout(20000);
+
+  it('should generate a report and exit 2 for stale dependencies', async () => {
+    const { status } = await rotten('only-stale.json');
+    assert.equal(status, 2, 'only stale should exit with code 2');
+  }).timeout(20000);
+
+  it('should output raw json when the json flag is passed', async () => {
+    const { stdout } = await rotten('rules-only-config.json', true);
+    const json = JSON.parse(stdout);
+    const chai = json.filter(x => x.name === 'chai').shift();
+    assert.equal(chai.name, 'chai');
+    assert.isFalse(chai.isIgnored);
+    assert.isTrue(chai.isOutdated);
+  }).timeout(20000);
+});

--- a/test/dummies/no-outdated.json
+++ b/test/dummies/no-outdated.json
@@ -6,9 +6,14 @@
       "daysUntilExpiration": 30
     },
     {
+      "dependencyName": "chai",
+      "ignore": true,
+      "daysUntilExpiration": 2000000
+    },
+    {
       "dependencyName": "left-pad",
-      "ignore": false,
-      "daysUntilExpiration": 9000
+      "ignore": true,
+      "daysUntilExpiration": 99999999999
     }
   ]
 }

--- a/test/dummies/only-stale.json
+++ b/test/dummies/only-stale.json
@@ -6,9 +6,14 @@
       "daysUntilExpiration": 30
     },
     {
+      "dependencyName": "chai",
+      "ignore": true,
+      "daysUntilExpiration": 2000000
+    },
+    {
       "dependencyName": "left-pad",
       "ignore": false,
-      "daysUntilExpiration": 9000
+      "daysUntilExpiration": 99999999999
     }
   ]
 }

--- a/test/dummies/sample-app/package.json
+++ b/test/dummies/sample-app/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "UNLICENSED",
   "devDependencies": {
+    "chai": "1.8.1",
     "mocha": "2.5.3"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "pretty": true,
     "types": [
       "node",
-      "yargs"
+      "yargs",
+      "mocha"
     ],
     "outDir": "./",
     "allowJs": true,

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,11 +1,14 @@
 module.exports = (wallaby) => ({
   testFramework: 'mocha',
   files: [
-    'src/**/*.ts',
+    'src/lib/*.ts',
+    { pattern: 'src/bin/rotten-deps.ts', instrument: false },
     { pattern: 'test/dummies/**/*', instrument: false },
   ],
   tests: [
     'test/*.test.js',
+    'test/*.test.ts',
+    '!test/cli.test.ts', // Wallaby doesn't handle CLI testing wekk
   ],
   env: {
     type: 'node',

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,6 +843,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/mocha@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.0.0.tgz#b0ba1c5b4cb3880c51a6b488ad007a657d1be888"
+  integrity sha512-jWeYcTo3sCH/rMgsdYXDTO85GNRyTCII5dayMIu/ZO4zbEot1E3iNGaOwpLReLUHjeNQFkgeNNVYlY4dX6azQQ==
+
 "@types/node@~14.0.14":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"


### PR DESCRIPTION
- upped timeouts for api tests again
- configures mocha for using TS files
- updates tsconfig type config to add mocha and chai types
- configures wallaby to ignore CLI tests for now. the sandbox it uses is causing errors.
- adds isStale check and corresponding exit code
- runs build before running test
- removes a lot of API documentation from the docs because this is going to be redone