### PR TITLE
enables strict typechecking

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/rotten-deps.js",
   "repository": "https://github.com/ominestre/rotten-deps",
   "scripts": {
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc --project tsconfig-build.json",
     "start": "npm run build && node ./bin/rotten-deps --config-path ./sample-config.json",
     "clean": "rimraf ./lib ./bin",
     "pretest": "(cd test/dummies/sample-app && npm install --no-audit) && npm run build",
@@ -18,8 +18,11 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/chai": "^4.2.13",
+    "@types/cli-table": "^0.3.0",
     "@types/mocha": "~8.0.3",
     "@types/node": "~14.11.8",
+    "@types/sinon": "^9.0.8",
     "@types/yargs": "~15.0.8",
     "@typescript-eslint/parser": "~4.4.0",
     "chai": "~4.2.0",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,5 @@
 import Table from 'cli-table';
-import { readFile } from 'fs';
-import { promisify } from 'util';
+import { readFileSync } from 'fs';
 
 
 interface Rule {
@@ -16,7 +15,7 @@ export interface Config {
 }
 
 interface FileReader {
-  (): Promise<String>;
+  (): Promise<string>;
 }
 
 interface Issue {
@@ -43,7 +42,14 @@ interface ErrorReport {
 
 type MaybeRules = ParsedRules | ErrorReport;
 
-export const parseRules = ({ rules }): MaybeRules => {
+
+/**
+ * reviews each rule of a configuration to determine validity
+ * generates a report of violations with recommendations on how to resolve
+ * @param config rotten deps configuration object
+ */
+const parseRules = (config: Config): MaybeRules => {
+  const { rules } = config;
   let problems: Problem[] = [];
   let isValidConfig = true;
   let parsedRules: Rule[] = [];
@@ -108,6 +114,11 @@ export const parseRules = ({ rules }): MaybeRules => {
 }
 
 
+/**
+ * Validates a raw configuration file and generates a report if any rules are
+ * misconfigured.
+ * @param config rotten deps configuration object
+ */
 export const createConfig = (config: Config): Config => {
   const maybeRules = parseRules(config);
   switch (maybeRules.kind) {
@@ -141,8 +152,10 @@ export const createConfig = (config: Config): Config => {
  * @param absoluteFilePath absolute path to the configuration file
  */
 export const createFileReader = (absoluteFilePath: string): FileReader => {
-  const readFilePromise = promisify(readFile);
-  return readFilePromise.bind(null, absoluteFilePath, { encoding: 'utf8' });
+  return async () => {
+    const data = readFileSync(absoluteFilePath, { encoding: 'utf-8' });
+    return String(data);
+  }
 };
 
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,7 +24,7 @@ export const generateReport = async (c: Config): Promise<ReportData[]|Error> => 
   if (outdated instanceof Error) return outdated;
 
   try {
-    const reportData = [];
+    const reportData: ReportData[] = [];
 
     Object.entries(outdated).forEach(async (x) => {
       const [name, desiredDetails]: [string, OutdatedPackage] = x;
@@ -52,9 +52,9 @@ export const generateReport = async (c: Config): Promise<ReportData[]|Error> => 
       const rule = rules.filter(x => x.dependencyName === name).shift();
 
       if (!rule) isOutdated = true;
-      if (!rule && config.defaultExpiration > daysOutdated) isOutdated = false;
-      if (rule && rule.daysUntilExpiration <= daysOutdated) isOutdated = true;
-      if (rule && rule.daysUntilExpiration > daysOutdated) isStale = true;
+      if (!rule && config.defaultExpiration && config.defaultExpiration > daysOutdated) isOutdated = false;
+      if (rule && rule.daysUntilExpiration && rule.daysUntilExpiration <= daysOutdated) isOutdated = true;
+      if (rule && rule.daysUntilExpiration && rule.daysUntilExpiration > daysOutdated) isStale = true;
 
       if (rule && rule.ignore) {
         isIgnored = true;

--- a/src/lib/npm-interactions.ts
+++ b/src/lib/npm-interactions.ts
@@ -1,8 +1,8 @@
 import * as proc from 'child_process';
 
-interface PackageDetails {
-  time?: object;
-  name?: string;
+export interface PackageDetails {
+  time: Record<string, string>;
+  name: string;
 }
 
 export interface OutdatedPackage {
@@ -58,7 +58,7 @@ export const createDetailsRequest = (dependencyName: string): DetailsRequest => 
   const command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
   const args = ['view', '--json', dependencyName];
 
-  return (): Promise<object> => new Promise(resolve => {
+  return (): Promise<PackageDetails | Error> => new Promise(resolve => {
     try {
       const response = proc.execFileSync(command, args, { encoding: 'utf8' });
       resolve(JSON.parse(response));

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -5,7 +5,7 @@ import { generateReport } from '../src/lib/index';
 
 
 const defaultDir = process.cwd();
-const changeDir = (directory) => () => process.chdir(directory);
+const changeDir = (directory: string) => () => process.chdir(directory);
 const restoreDir = changeDir(defaultDir);
 const sampleAppDir = changeDir(
   join(__dirname, './dummies/sample-app'),
@@ -13,7 +13,7 @@ const sampleAppDir = changeDir(
 
 
 const sampleConfigDir = join(__dirname, './dummies/');
-const getTestConfig = (configID) => JSON.parse(readFileSync(`${sampleConfigDir}/${configID}.json`, { encoding: 'utf8' }));
+const getTestConfig = (configID: string) => JSON.parse(readFileSync(`${sampleConfigDir}/${configID}.json`, { encoding: 'utf8' }));
 
 
 describe('API integrations', () => {
@@ -26,28 +26,47 @@ describe('API integrations', () => {
 
     if (maybeReport instanceof Error) throw maybeReport;
 
-    const filter = name => maybeReport.filter(x => x.name === name).shift();
+    const filter = (name: string) => maybeReport.filter(x => x.name === name).shift();
     const leftPadLOL = filter('left-pad');
     const mocha = filter('mocha');
     const chai = filter('chai');
 
+    // https://github.com/microsoft/TypeScript/issues/19573
+    // created in 2017 for supporting block ignore :(
+
+    // @ts-ignore
     assert.equal(leftPadLOL.name, 'left-pad');
+    // @ts-ignore
     assert.equal(leftPadLOL.current, '1.2.0');
+    // @ts-ignore
     assert.isTrue(leftPadLOL.daysOutdated < 9000, 'Days Outdated should be less than 9000');
+    // @ts-ignore
     assert.isFalse(leftPadLOL.isOutdated, 'left-pad should not be flagged as outdated');
+    // @ts-ignore
     assert.isTrue(leftPadLOL.isStale, 'left-pad 1.2 should be flagged as stale since 1.3 is latest');
 
+    // @ts-ignore
     assert.equal(mocha.name, 'mocha');
+    // @ts-ignore
     assert.equal(mocha.current, '2.5.3');
+    // @ts-ignore
     assert.isTrue(mocha.isIgnored);
+    // @ts-ignoreZS
     assert.isFalse(mocha.isOutdated);
+    // @ts-ignore
     assert.isFalse(mocha.isStale);
 
+    // @ts-ignore
     assert.equal(chai.name, 'chai');
+    // @ts-ignore
     assert.equal(chai.current, '1.8.1');
+    // @ts-ignore
     assert.isTrue(chai.daysOutdated > 1800);
+    // @ts-ignore
     assert.isTrue(chai.isOutdated);
+    // @ts-ignore
     assert.isFalse(chai.isIgnored);
+    // @ts-ignore
     assert.isFalse(chai.isStale);
   }).timeout(20000);
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,11 +2,7 @@ import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { assert } from 'chai';
 
-interface CommandResponse {
-  status: number;
-  stdout: string;
-  stderr: string;
-}
+import type { PackageDetails } from '../src/lib/npm-interactions';
 
 type ConfigName = 'rules-only-config.json' | 'only-stale.json' | 'no-outdated.json';
 
@@ -15,7 +11,7 @@ const rotten = ({
   enableJSON = false,
   configFileName = '',
   defaultDays = 0,
-}): CommandResponse => {
+}) => {
   const configPath = join(__dirname, `dummies/${configFileName}`);
   const dummyApp = join(__dirname, 'dummies/sample-app/');
   const binaryPath = join(__dirname, '../bin/rotten-deps');
@@ -64,7 +60,7 @@ describe('CLI', () => {
   it('should output raw json when the json flag is passed', async () => {
     const { stdout } = await rotten({ configFileName: 'rules-only-config.json', enableJSON: true});
     const json = JSON.parse(stdout);
-    const chai = json.filter(x => x.name === 'chai').shift();
+    const chai = json.filter((x: PackageDetails) => x.name === 'chai').shift();
     assert.equal(chai.name, 'chai');
     assert.isFalse(chai.isIgnored);
     assert.isTrue(chai.isOutdated);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -33,6 +33,7 @@ describe('Configuration library', () => {
     const b = configLib.createConfig.bind(null, {
       rules: [
         { dependencyName: 'foo', ignore: true, daysUntilExpiration: 300 },
+        // @ts-ignore intentionally passing bad values
         { dependencyName: null, ignore: true, daysUntilExpiration: 9001 },
       ],
     });

--- a/test/npm-interactions.test.ts
+++ b/test/npm-interactions.test.ts
@@ -7,7 +7,8 @@ import npmLib from '../src/lib/npm-interactions';
  * `Object.defineProperty` method
  * @param {string} platform
  */
-const setProcessPlatform = platform => () => Object.defineProperty(process, 'platform', { value: platform });
+const setProcessPlatform = (platform: string) =>
+  () => Object.defineProperty(process, 'platform', { value: platform });
 
 const defaultPlatform = process.platform;
 const restorePlatform = setProcessPlatform(defaultPlatform);

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,15 @@
       "yargs",
       "mocha"
     ],
-    "outDir": "./",
+    "outDir": "./build",
     "allowJs": true,
-    "target": "ES5"
+    "target": "ES5",
+    "strict": true,
+    "alwaysStrict": true,
   },
   "include": [
-    "./src/**/*"
+    "./src/**/*",
+    "./test/**/*",
   ],
   "exclude": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,16 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@types/chai@^4.2.13":
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.13.tgz#8a3801f6655179d1803d81e94a2e4aaf317abd16"
+  integrity sha512-o3SGYRlOpvLFpwJA6Sl1UPOwKFEvE4FxTEB/c9XHI2whdnd4kmPVkNLL8gY4vWGBxWWDumzLbKsAhEH5SKn37Q==
+
+"@types/cli-table@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cli-table/-/cli-table-0.3.0.tgz#f1857156bf5fd115c6a2db260ba0be1f8fc5671c"
+  integrity sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -124,6 +134,18 @@
   version "14.11.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
   integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
+
+"@types/sinon@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.8.tgz#1ed0038d356784f75b086104ef83bfd4130bb81b"
+  integrity sha512-IVnI820FZFMGI+u1R+2VdRaD/82YIQTdqLYC9DLPszZuynAJDtCvCtCs3bmyL66s7FqRM3+LPX7DhHnVTaagDw==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
+  integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
 
 "@types/yargs-parser@*":
   version "15.0.0"


### PR DESCRIPTION
- fixes existing compiler issues
- adds cli-table type definitions
- adds chai type definitions
- adds sinon type definitions
- adds secondary ts config

The secondary tsconfig is for production builds because we only want
to compile the source